### PR TITLE
feat: Traefik DNS-01チャレンジをCloudflareに対応

### DIFF
--- a/.env.cloudflare.example
+++ b/.env.cloudflare.example
@@ -1,0 +1,14 @@
+# 自身のemail
+CA_EMAIL=
+# https://zerossl.com からログインしてdeveloperにあるEAB Credentials for ACME ClientsからGenerateする
+EAB_KID=
+EAB_HMAC_KEY=
+
+# Cloudflare DNS設定
+# My Profile → API Tokens → Create Token → Custom token で発行する
+# 必要な権限: Zone → DNS → Edit, Zone → Zone → Read
+# Zone Resources は challtech.dev のみに限定する（Global API Keyは使わない）
+CF_DNS_API_TOKEN=
+
+# CoreDNSで独自の設定ファイルを使用したい場合
+# CORE_FILE=./docker/dns/custom.Corefile

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !/docker/dns/Corefile
 /docker/dns/*
 /docker/mysql/data/
+/.superpowers/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 1. `.env.gcloud.example`をコピーして`.env`を作成する
 2. `.env`の項目を全部埋める（GCP 関連の環境変数を設定）
 
+### Cloudflare を使用する場合
+
+1. `.env.cloudflare.example`をコピーして`.env`を作成する
+2. `.env`の項目を全部埋める（`CF_DNS_API_TOKEN` を設定）
+
 ### ネットワーク作成
 
 ```sh
@@ -31,6 +36,12 @@ docker compose -f compose.aws.yaml up -d
 
 ```sh
 docker compose -f compose.gcloud.yaml up -d
+```
+
+#### Cloudflare を使用する場合
+
+```sh
+docker compose -f compose.cloudflare.yaml up -d
 ```
 
 ### URL

--- a/compose.cloudflare.yaml
+++ b/compose.cloudflare.yaml
@@ -1,0 +1,151 @@
+services:
+  proxy:
+    image: traefik:v3.6.2
+    ports:
+      - "80:80"
+      - "443:443"
+      - "6001:6001"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ssl:/zerossl
+    environment:
+      CF_DNS_API_TOKEN: "${CF_DNS_API_TOKEN}"
+    networks:
+      default:
+      web:
+        ipv4_address: 192.168.100.250
+    restart: always
+    dns:
+      - "1.1.1.1"
+    command:
+      - "--log.level=DEBUG"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.forwardedHeaders.insecure=true"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.forwardedHeaders.insecure=true"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--certificatesresolvers.zerossl.acme.dnschallenge=true"
+      - "--certificatesresolvers.zerossl.acme.dnschallenge.provider=cloudflare"
+      - "--certificatesresolvers.zerossl.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53"
+      - "--certificatesresolvers.zerossl.acme.caserver=https://acme.zerossl.com/v2/DV90"
+      - "--certificatesresolvers.zerossl.acme.email=${CA_EMAIL}"
+      - "--certificatesresolvers.zerossl.acme.storage=/zerossl/acme.json"
+      - "--certificatesresolvers.zerossl.acme.eab.kid=${EAB_KID}"
+      - "--certificatesresolvers.zerossl.acme.eab.hmacEncoded=${EAB_HMAC_KEY}"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web"
+      - "traefik.http.routers.proxy.rule=Host(`proxy.local.challtech.dev`)"
+      - "traefik.http.routers.proxy.tls=true"
+      - "traefik.http.routers.proxy.tls.certresolver=zerossl"
+      - "traefik.http.services.proxy.loadbalancer.server.port=8080"
+      - "traefik.http.routers.proxy.tls.domains[0].main=local.challtech.dev"
+      - "traefik.http.routers.proxy.tls.domains[0].sans=*.local.challtech.dev"
+  mysql8:
+    image: mysql/mysql-server:8.0.23
+    ports:
+      - "${MYSQL8_PORT:-3306}:3306"
+    volumes:
+      - ./docker/mysql/data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: "${DB_PASSWORD:-password}"
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_USER: "${DB_USERNAME:-super}"
+      MYSQL_PASSWORD: "${DB_PASSWORD:-password}"
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    networks:
+      dev-container:
+    restart: always
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password --sql_mode="NO_ENGINE_SUBSTITUTION"
+
+  redis6:
+    image: redis:6-alpine
+    volumes:
+      - redis6:/data
+    ports:
+      - "6379:6379"
+    networks:
+      dev-container:
+    restart: always
+
+  mail:
+    image: axllent/mailpit
+    volumes:
+      - mail:/mailpitstorage
+    environment:
+      TZ: Asia/Tokyo
+      MP_DATA_FILE: /mailpitstorage/mailpit.db
+    ports:
+      - "${FORWARD_MAIL_SMTP_PORT:-1025}:1025"
+    networks:
+      default:
+      dev-container:
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=dev-container_default"
+      - "traefik.http.routers.mail.rule=Host(`mail.local.challtech.dev`)"
+      - "traefik.http.routers.mail.tls=true"
+      - "traefik.http.routers.mail.tls.certresolver=zerossl"
+      - "traefik.http.services.mail.loadbalancer.server.port=8025"
+
+  minio:
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+    entrypoint: bash
+    command: >
+      -c "
+      mkdir -p /data/.minio.sys/buckets;
+      cp -r /policies/* /data/.minio.sys/;
+      cp -r /export/* /data/;
+      /usr/bin/docker-entrypoint.sh minio server /data --console-address :9001;
+      "
+    volumes:
+      - ./docker/minio/data:/data
+      - ./docker/minio/export:/export
+      - ./docker/minio/config:/root/.minio
+      - ./docker/minio/policies:/policies
+    ports:
+      - "9000:9000"
+    expose:
+      - 9001
+    networks:
+      default:
+      dev-container:
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=dev-container_default"
+      - "traefik.http.routers.minio.rule=Host(`minio.local.challtech.dev`)"
+      - "traefik.http.routers.minio.tls=true"
+      - "traefik.http.routers.minio.tls.certresolver=zerossl"
+      - "traefik.http.services.minio.loadbalancer.server.port=9001"
+  dns:
+    image: coredns/coredns:1.11.1
+    volumes:
+      - "${CORE_FILE:-./docker/dns/Corefile}:/etc/coredns/Corefile"
+    ports:
+      - "53:53"
+      - "53:53/udp"
+    networks:
+      default:
+    profiles:
+      - dns
+    command: -conf /etc/coredns/Corefile
+
+networks:
+  web:
+    external: true
+  dev-container:
+    external: true
+
+volumes:
+  redis6:
+  ssl:
+  mail:

--- a/docs/superpowers/plans/2026-07-18-traefik-cloudflare-dns-migration.md
+++ b/docs/superpowers/plans/2026-07-18-traefik-cloudflare-dns-migration.md
@@ -1,0 +1,392 @@
+# Traefik Cloudflare DNS 移行 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Traefik の ACME DNS-01 チャレンジを Google Cloud DNS から Cloudflare に切り替えるための Cloudflare 版 compose / env / ドキュメントをリポジトリに追加する。
+
+**Architecture:** 既存のプロバイダ別パターン（`compose.<provider>.yaml` + `.env.<provider>.example`）を踏襲し、`compose.gcloud.yaml` をベースに Cloudflare 版を新規追加する。CA は ZeroSSL のまま（resolver 名 `zerossl` / caserver / EAB を維持）、変更は DNS プロバイダと認証方式（GCP secrets → `CF_DNS_API_TOKEN` env）のみ。gcloud/aws 版はロールバック用に残す。
+
+**Tech Stack:** Docker Compose, Traefik v3.6.2, ZeroSSL (ACME + EAB), Cloudflare DNS API (lego cloudflare provider), Docker Compose 環境変数補間。
+
+## Global Constraints
+
+- Traefik イメージは `traefik:v3.6.2` を維持（既存 aws/gcloud と同一）。
+- ACME resolver 名は `zerossl` を維持。caserver `https://acme.zerossl.com/v2/DV90`、EAB（`EAB_KID` / `EAB_HMAC_KEY`）、email（`CA_EMAIL`）は変更しない。
+- 対象ドメインは `local.challtech.dev`（main）+ `*.local.challtech.dev`（SANs）。各サービスの Traefik ラベルは変更しない。
+- Cloudflare 認証は環境変数 `CF_DNS_API_TOKEN` のみ（Docker secrets / サービスアカウントファイルは使わない）。
+- 証明書ストレージは名前付きボリューム `ssl:/zerossl`、`storage=/zerossl/acme.json` を維持。
+- gcloud / aws の既存ファイルは削除しない。
+- 作業ブランチ: `feat/traefik-cloudflare-dns`。
+- `.env` は `.gitignore` 済み。実トークン等の秘匿値はコミットしない。
+
+---
+
+### Task 1: `.env.cloudflare.example` の作成
+
+**Files:**
+- Create: `/Users/seiyu/workspaces/projects/dev-container/.env.cloudflare.example`
+
+**Interfaces:**
+- Produces: 環境変数 `CA_EMAIL`, `EAB_KID`, `EAB_HMAC_KEY`, `CF_DNS_API_TOKEN` の雛形。Task 2 の `compose.cloudflare.yaml` がこれらを参照する。
+
+- [ ] **Step 1: ベースとの差分を確認**
+
+Run: `cat .env.gcloud.example`
+Expected: GCP 用ブロック（`GCP_SERVICE_ACCOUNT_FILE` / `GCP_PROJECT_ID`）を含む雛形が表示される。この GCP ブロックを Cloudflare 用に置き換える。
+
+- [ ] **Step 2: `.env.cloudflare.example` を作成**
+
+以下の内容で新規作成する:
+
+```dotenv
+# 自身のemail
+CA_EMAIL=
+# https://zerossl.com からログインしてdeveloperにあるEAB Credentials for ACME ClientsからGenerateする
+EAB_KID=
+EAB_HMAC_KEY=
+
+# Cloudflare DNS設定
+# My Profile → API Tokens → Create Token → Custom token で発行する
+# 必要な権限: Zone → DNS → Edit, Zone → Zone → Read
+# Zone Resources は challtech.dev のみに限定する（Global API Keyは使わない）
+CF_DNS_API_TOKEN=
+
+# CoreDNSで独自の設定ファイルを使用したい場合
+# CORE_FILE=./docker/dns/custom.Corefile
+```
+
+- [ ] **Step 3: 検証（GCP 変数が残っていないこと）**
+
+Run: `grep -E 'GCP_|GCE_' .env.cloudflare.example; echo "exit=$?"`
+Expected: 一致なし（`exit=1`）。`CF_DNS_API_TOKEN=` の行が存在すること（`grep CF_DNS_API_TOKEN .env.cloudflare.example` で確認）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.cloudflare.example
+git commit -m "feat: Cloudflare DNS用の.envサンプルを追加"
+```
+
+---
+
+### Task 2: `compose.cloudflare.yaml` の作成
+
+**Files:**
+- Create: `/Users/seiyu/workspaces/projects/dev-container/compose.cloudflare.yaml`
+
+**Interfaces:**
+- Consumes: Task 1 の環境変数（`CA_EMAIL`, `EAB_KID`, `EAB_HMAC_KEY`, `CF_DNS_API_TOKEN`）。
+- Produces: `docker compose -f compose.cloudflare.yaml up -d` で起動可能な Cloudflare 版 Traefik 構成。
+
+- [ ] **Step 1: ベースとの差分を把握**
+
+Run: `sed -n '1,53p' compose.gcloud.yaml`
+Expected: 冒頭に `secrets:` ブロック、`proxy` に `secrets:` / `environment:`（`GCE_*`）/ `provider=gcloud` があることを確認。これらが Cloudflare 版での変更対象。
+
+- [ ] **Step 2: `compose.cloudflare.yaml` を作成**
+
+以下の内容で新規作成する（gcloud 版から `secrets` 削除・`environment` を `CF_DNS_API_TOKEN` のみに・`provider=cloudflare`・`resolvers` 追加）:
+
+```yaml
+services:
+  proxy:
+    image: traefik:v3.6.2
+    ports:
+      - "80:80"
+      - "443:443"
+      - "6001:6001"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ssl:/zerossl
+    environment:
+      CF_DNS_API_TOKEN: "${CF_DNS_API_TOKEN}"
+    networks:
+      default:
+      web:
+        ipv4_address: 192.168.100.250
+    restart: always
+    dns:
+      - "1.1.1.1"
+    command:
+      - "--log.level=DEBUG"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.forwardedHeaders.insecure=true"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.forwardedHeaders.insecure=true"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--certificatesresolvers.zerossl.acme.dnschallenge=true"
+      - "--certificatesresolvers.zerossl.acme.dnschallenge.provider=cloudflare"
+      - "--certificatesresolvers.zerossl.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53"
+      - "--certificatesresolvers.zerossl.acme.caserver=https://acme.zerossl.com/v2/DV90"
+      - "--certificatesresolvers.zerossl.acme.email=${CA_EMAIL}"
+      - "--certificatesresolvers.zerossl.acme.storage=/zerossl/acme.json"
+      - "--certificatesresolvers.zerossl.acme.eab.kid=${EAB_KID}"
+      - "--certificatesresolvers.zerossl.acme.eab.hmacEncoded=${EAB_HMAC_KEY}"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web"
+      - "traefik.http.routers.proxy.rule=Host(`proxy.local.challtech.dev`)"
+      - "traefik.http.routers.proxy.tls=true"
+      - "traefik.http.routers.proxy.tls.certresolver=zerossl"
+      - "traefik.http.services.proxy.loadbalancer.server.port=8080"
+      - "traefik.http.routers.proxy.tls.domains[0].main=local.challtech.dev"
+      - "traefik.http.routers.proxy.tls.domains[0].sans=*.local.challtech.dev"
+  mysql8:
+    image: mysql/mysql-server:8.0.23
+    ports:
+      - "${MYSQL8_PORT:-3306}:3306"
+    volumes:
+      - ./docker/mysql/data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: "${DB_PASSWORD:-password}"
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_USER: "${DB_USERNAME:-super}"
+      MYSQL_PASSWORD: "${DB_PASSWORD:-password}"
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    networks:
+      dev-container:
+    restart: always
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password --sql_mode="NO_ENGINE_SUBSTITUTION"
+
+  redis6:
+    image: redis:6-alpine
+    volumes:
+      - redis6:/data
+    ports:
+      - "6379:6379"
+    networks:
+      dev-container:
+    restart: always
+
+  mail:
+    image: axllent/mailpit
+    volumes:
+      - mail:/mailpitstorage
+    environment:
+      TZ: Asia/Tokyo
+      MP_DATA_FILE: /mailpitstorage/mailpit.db
+    ports:
+      - "${FORWARD_MAIL_SMTP_PORT:-1025}:1025"
+    networks:
+      default:
+      dev-container:
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=dev-container_default"
+      - "traefik.http.routers.mail.rule=Host(`mail.local.challtech.dev`)"
+      - "traefik.http.routers.mail.tls=true"
+      - "traefik.http.routers.mail.tls.certresolver=zerossl"
+      - "traefik.http.services.mail.loadbalancer.server.port=8025"
+
+  minio:
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+    entrypoint: bash
+    command: >
+      -c "
+      mkdir -p /data/.minio.sys/buckets;
+      cp -r /policies/* /data/.minio.sys/;
+      cp -r /export/* /data/;
+      /usr/bin/docker-entrypoint.sh minio server /data --console-address :9001;
+      "
+    volumes:
+      - ./docker/minio/data:/data
+      - ./docker/minio/export:/export
+      - ./docker/minio/config:/root/.minio
+      - ./docker/minio/policies:/policies
+    ports:
+      - "9000:9000"
+    expose:
+      - 9001
+    networks:
+      default:
+      dev-container:
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=dev-container_default"
+      - "traefik.http.routers.minio.rule=Host(`minio.local.challtech.dev`)"
+      - "traefik.http.routers.minio.tls=true"
+      - "traefik.http.routers.minio.tls.certresolver=zerossl"
+      - "traefik.http.services.minio.loadbalancer.server.port=9001"
+  dns:
+    image: coredns/coredns:1.11.1
+    volumes:
+      - "${CORE_FILE:-./docker/dns/Corefile}:/etc/coredns/Corefile"
+    ports:
+      - "53:53"
+      - "53:53/udp"
+    networks:
+      default:
+    profiles:
+      - dns
+    command: -conf /etc/coredns/Corefile
+
+networks:
+  web:
+    external: true
+  dev-container:
+    external: true
+
+volumes:
+  redis6:
+  ssl:
+  mail:
+```
+
+- [ ] **Step 3: 構成の静的検証（YAML + 環境変数補間）**
+
+Run: `CF_DNS_API_TOKEN=dummy CA_EMAIL=test@example.com EAB_KID=k EAB_HMAC_KEY=h docker compose -f compose.cloudflare.yaml config >/dev/null && echo OK`
+Expected: `OK`（YAML 妥当・環境変数補間成功）。エラーが出た場合はインデント/構文を修正。
+
+- [ ] **Step 4: 差分検証（gcloud 版との想定差分のみか）**
+
+Run: `grep -nE 'provider=|CF_DNS_API_TOKEN|GCE_|secrets|resolvers=' compose.cloudflare.yaml`
+Expected: `provider=cloudflare` と `CF_DNS_API_TOKEN` と `resolvers=1.1.1.1:53,8.8.8.8:53` が存在し、`GCE_` と `secrets` が**存在しない**こと。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add compose.cloudflare.yaml
+git commit -m "feat: Cloudflare DNS用のcompose定義を追加"
+```
+
+---
+
+### Task 3: `README.md` に Cloudflare 手順を追加
+
+**Files:**
+- Modify: `/Users/seiyu/workspaces/projects/dev-container/README.md`
+
+**Interfaces:**
+- Consumes: Task 1 / Task 2 で追加したファイル名（`.env.cloudflare.example`, `compose.cloudflare.yaml`）。
+
+- [ ] **Step 1: 既存構成を確認**
+
+Run: `cat README.md`
+Expected: 「AWS Route53 を使用する場合」「Google Cloud DNS を使用する場合」の環境構築セクションと起動セクションがある。ここに Cloudflare 版を同じ体裁で追記する。
+
+- [ ] **Step 2: 環境構築セクションに追記**
+
+`### Google Cloud DNS を使用する場合` の環境構築ブロック（`2. \`.env\`の項目を全部埋める（GCP 関連の環境変数を設定）` の行の直後）に、以下を追加する:
+
+```markdown
+
+### Cloudflare を使用する場合
+
+1. `.env.cloudflare.example`をコピーして`.env`を作成する
+2. `.env`の項目を全部埋める（`CF_DNS_API_TOKEN` を設定）
+```
+
+- [ ] **Step 3: 起動セクションに追記**
+
+`#### Google Cloud DNS を使用する場合` の起動ブロック（gcloud の ```` ```sh ... docker compose -f compose.gcloud.yaml up -d ... ``` ```` コードブロックの直後）に、以下を追加する:
+
+````markdown
+
+#### Cloudflare を使用する場合
+
+```sh
+docker compose -f compose.cloudflare.yaml up -d
+```
+````
+
+- [ ] **Step 4: 検証**
+
+Run: `grep -c 'compose.cloudflare.yaml' README.md`
+Expected: `1` 以上。`grep -c 'Cloudflare' README.md` で 2 箇所（環境構築・起動）追記されていること。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: READMEにCloudflare利用手順を追加"
+```
+
+---
+
+### Task 4: ローカル `.env` に `CF_DNS_API_TOKEN` を追加（運用者作業）
+
+**Files:**
+- Modify: `/Users/seiyu/workspaces/projects/dev-container/.env`（`.gitignore` 済み・コミットしない）
+
+**Interfaces:**
+- Consumes: 運用者が Cloudflare で発行した API トークン（DNS:Edit + Zone:Read、Zone は challtech.dev 限定）。
+
+- [ ] **Step 1: トークンの有効性を単体確認**
+
+（トークン発行後）Run: `curl -s -H "Authorization: Bearer <発行したトークン>" "https://api.cloudflare.com/client/v4/user/tokens/verify" | jq -r '.result.status'`
+Expected: `active`
+
+- [ ] **Step 2: `.env` に行を追加**
+
+`.env` の末尾（GCP 行は残したまま）に以下を追加する。`<...>` は実トークンに置換:
+
+```dotenv
+# Cloudflare DNS設定
+CF_DNS_API_TOKEN=<発行したトークン>
+```
+
+- [ ] **Step 3: 補間確認（秘匿値を出力しない）**
+
+Run: `docker compose -f compose.cloudflare.yaml config | grep -c 'CF_DNS_API_TOKEN'`
+Expected: `1`（値は表示せず存在のみ確認。エラー/警告が出ないこと）。
+
+- [ ] **Step 4: コミットしないことを確認**
+
+Run: `git status --porcelain .env; echo "exit=$?"`
+Expected: `.env` が出力されない（`.gitignore` 済みのため追跡対象外）。**このタスクはコミットしない。**
+
+---
+
+### Task 5: 切替（運用者作業・任意タイミング）
+
+**Files:** なし（Docker 操作のみ）
+
+**Interfaces:**
+- Consumes: Task 2 の `compose.cloudflare.yaml`、Task 4 の `.env`。
+
+> 設計方針により証明書は既存 `ssl` ボリュームの acme.json を流用し強制再取得はしない。詳細な切替/ロールバック/CAA/Cloud DNS 後片付け手順は設計ドキュメント `docs/superpowers/specs/2026-07-18-traefik-cloudflare-dns-migration-design.md` の「運用ランブック」を参照。
+
+- [ ] **Step 1: gcloud 版を停止**
+
+Run: `docker compose -f compose.gcloud.yaml down`
+Expected: proxy 等が停止する。
+
+- [ ] **Step 2: Cloudflare 版で起動**
+
+Run: `docker compose -f compose.cloudflare.yaml up -d`
+Expected: コンテナが起動する。
+
+- [ ] **Step 3: proxy ログ確認**
+
+Run: `docker compose -f compose.cloudflare.yaml logs --tail=50 proxy`
+Expected: エラーなく起動。証明書エラーが出ないこと（既存証明書流用のため通常は再取得ログは出ない）。
+
+- [ ] **Step 4: ロールバック手順（問題発生時のみ）**
+
+Run: `docker compose -f compose.cloudflare.yaml down && docker compose -f compose.gcloud.yaml up -d`
+Expected: gcloud 版に復帰。`ssl` ボリューム（acme.json）は共有のため既存証明書をそのまま使う。
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- compose.cloudflare.yaml 作成 → Task 2 ✓
+- .env.cloudflare.example 作成 → Task 1 ✓
+- .env 更新（CF_DNS_API_TOKEN） → Task 4 ✓
+- README 更新 → Task 3 ✓
+- 運用ランブック（トークン検証/切替/ロールバック/CAA/Cloud DNS 後片付け） → 設計ドキュメント参照 + Task 4/5 で実行部分をカバー ✓
+- ZeroSSL 維持・provider のみ変更・resolvers 追加・secrets 削除 → Task 2 の内容に反映 ✓
+
+**2. Placeholder scan:** `<発行したトークン>` は運用者が置換する実値プレースホルダ（秘匿値のため plan に実値は書けない）。それ以外に TODO/TBD なし。
+
+**3. Type consistency:** ファイル名（`compose.cloudflare.yaml` / `.env.cloudflare.example`）、環境変数名（`CF_DNS_API_TOKEN`）、resolver 名（`zerossl`）は全タスクで一貫。

--- a/docs/superpowers/specs/2026-07-18-traefik-cloudflare-dns-migration-design.md
+++ b/docs/superpowers/specs/2026-07-18-traefik-cloudflare-dns-migration-design.md
@@ -1,0 +1,140 @@
+# Traefik DNS-01 チャレンジ Cloudflare 移行 設計
+
+## 背景
+
+ドメイン `challtech.dev` の権威 DNS を Google Cloud DNS から Cloudflare へ移行済み
+（NS: `anton.ns.cloudflare.com` / `demi.ns.cloudflare.com`、切替確認済み）。
+Traefik の ACME DNS-01 チャレンジはまだ Google Cloud DNS 向け設定のため、
+DNS プロバイダを Cloudflare に差し替える。
+
+## 確定した決定事項
+
+| 項目 | 決定 | 理由 |
+|------|------|------|
+| CA | ZeroSSL 維持 | 既存 resolver `zerossl` / caserver / EAB 認証を流用。変更は DNS プロバイダのみでリスク最小 |
+| ファイル構成 | Cloudflare 版を新規追加、gcloud/aws は残す | 既存のプロバイダ別パターン（`compose.<provider>.yaml`）踏襲。ロールバック可能 |
+| 証明書 | 既存 `ssl` ボリュームの acme.json を流用、強制再取得なし | ドメイン不変のため既存証明書は失効まで有効。自然更新時に新プロバイダが使われる |
+
+## リポジトリ変更（成果物）
+
+### 1. `compose.cloudflare.yaml`（新規）
+
+`compose.gcloud.yaml` をベースに以下だけ差し替える。
+
+- ファイル冒頭の `secrets:` ブロックを削除（GCP サービスアカウント JSON 不要）
+- `proxy` サービスの `secrets:` 参照を削除
+- `proxy` の `environment:` を `CF_DNS_API_TOKEN: "${CF_DNS_API_TOKEN}"` のみに変更（`GCE_SERVICE_ACCOUNT_FILE` / `GCE_PROJECT` を削除）
+- command の `--certificatesresolvers.zerossl.acme.dnschallenge.provider=gcloud` → `cloudflare`
+- command に `--certificatesresolvers.zerossl.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53` を追加
+  （TXT レコード伝播チェックを外部リゾルバで行い、ローカルリゾルバによる誤判定を防ぐ）
+- caserver / email / storage / eab.kid / eab.hmacEncoded は **変更なし**
+- 各サービス（proxy / mail / minio）の Traefik ラベルは **変更なし**（`tls.certresolver=zerossl` 等そのまま）
+- mysql8 / redis6 / mail / minio / dns / networks / volumes は gcloud 版と同一
+
+### 2. `.env.cloudflare.example`（新規）
+
+`.env.gcloud.example` をベースに、GCP 設定ブロックを削除し Cloudflare 設定を追加。
+
+```
+# 自身のemail
+CA_EMAIL=
+# https://zerossl.com からログインしてdeveloperにあるEAB Credentials for ACME ClientsからGenerateする
+EAB_KID=
+EAB_HMAC_KEY=
+
+# Cloudflare DNS設定
+# My Profile → API Tokens → Create Token → Custom token で発行する
+# 必要な権限: Zone → DNS → Edit, Zone → Zone → Read
+# Zone Resources は challtech.dev のみに限定する（Global API Keyは使わない）
+CF_DNS_API_TOKEN=
+
+# CoreDNSで独自の設定ファイルを使用したい場合
+# CORE_FILE=./docker/dns/custom.Corefile
+```
+
+### 3. `.env`（更新）
+
+`CF_DNS_API_TOKEN=<実トークン>` の行を追加する（実トークンは運用者が記入）。
+GCP 関連行はロールバック用に残す。`.env` は `.gitignore` 済みのためコミットされない。
+
+### 4. `README.md`（更新）
+
+「Cloudflare を使用する場合」セクションを環境構築・起動の両方に追加。
+
+```sh
+docker compose -f compose.cloudflare.yaml up -d
+```
+
+## 運用ランブック（リポジトリ外の手作業）
+
+これらは DNS 側の運用手順であり、リポジトリのファイル変更ではない。
+
+### A. Cloudflare API トークン発行
+Cloudflare ダッシュボード → My Profile → API Tokens → Create Token → Custom token
+- 権限: `Zone → DNS → Edit`, `Zone → Zone → Read`
+- Zone Resources: `challtech.dev` のみに限定（Global API Key は使わない）
+- 発行値を `.env` の `CF_DNS_API_TOKEN` に設定
+
+### B. DNS レコード確認
+- `*.local.challtech.dev A → 127.0.0.1`、**DNS only（グレー雲）** 必須
+  （プロキシ ON だとループバック/プライベート IP は登録エラー。他端末からもアクセスするなら
+  `127.0.0.1` ではなく Traefik ホストの LAN IP に）
+- DNS-01 チャレンジ自体は Traefik が `_acme-challenge.local.challtech.dev` の TXT を
+  Cloudflare API 経由で作成・削除するため、上記 A レコードは名前解決用
+
+### C. CAA レコードの注意
+ZeroSSL の証明書発行元は **Sectigo**。CAA を張る場合は次のいずれか。
+- `challtech.dev. CAA 0 issue "sectigo.com"`
+- CAA を張らない（誰でも発行可＝デフォルト）
+
+**重要**: 旧 Google Cloud DNS 由来の `0 issue "pki.goog"` が残っていると ZeroSSL/Sectigo が
+弾かれるため、削除するか `sectigo.com` に置き換える。
+
+### D. トークン単体の疎通確認（acme.json に触れず検証）
+自然更新を待つ方針のため、更新が走る前にトークンの有効性を単体で確認しておく。
+
+```sh
+curl -s -H "Authorization: Bearer $CF_DNS_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/user/tokens/verify" | jq .
+# → "status": "active" を確認
+```
+
+### E. 切替とロールバック
+
+切替:
+```sh
+docker compose -f compose.gcloud.yaml down
+docker compose -f compose.cloudflare.yaml up -d
+docker compose -f compose.cloudflare.yaml logs -f proxy
+```
+
+ロールバック（Cloudflare 側で問題が出た場合）:
+```sh
+docker compose -f compose.cloudflare.yaml down
+docker compose -f compose.gcloud.yaml up -d
+```
+
+`ssl` ボリューム（acme.json）は共有のため、切替・ロールバックとも既存証明書をそのまま使う。
+
+### F. Cloud DNS の後片付け（移行安定後）
+1. バックアップをエクスポート
+   ```sh
+   gcloud dns record-sets export challtech-dev-backup.txt --zone=YOUR_ZONE --zone-file-format
+   ```
+2. MX / TXT（SPF・DKIM・DMARC）が存在する場合、Cloudflare 側へ移行済みか確認
+   （例: `dig MX challtech.dev`, `dig TXT challtech.dev` を Cloudflare NS 相手に）
+3. 証明書更新が Cloudflare 経由で通り、数日安定してからゾーンを削除
+   （レコードを先に削除する必要あり）
+
+## 検証方針の補足（トレードオフ）
+
+強制再取得しないため、Traefik 起動直後には Cloudflare DNS-01 の成否は分からない。
+リスク低減として運用ランブック D（トークン単体疎通確認）を必ず実施する。
+更新が走る残 30 日時点で `Certificates obtained for domain` がログに出れば移行成功。
+失敗時は E のロールバックで gcloud に即戻せる。
+
+## スコープ外
+
+- Let's Encrypt への CA 変更（今回は ZeroSSL 維持）
+- gcloud / aws プロバイダ設定の削除（ロールバック用に残す）
+- 証明書の強制再取得


### PR DESCRIPTION
## 概要
`challtech.dev` の権威DNSをGoogle Cloud DNS→Cloudflareへ移行したのに合わせ、TraefikのACME DNS-01チャレンジをCloudflareで実行できるようにする。既存のプロバイダ別パターン（`compose.<provider>.yaml` + `.env.<provider>.example`）を踏襲し、Cloudflare版を新規追加する。

## 方針
- **CAは変更なし（ZeroSSL維持）** — resolver名 `zerossl` / caserver / EAB認証はそのまま。変更はDNSプロバイダのみ。
- **gcloud/aws版は残す** — ロールバック可能。
- 認証はDocker secrets（GCPサービスアカウントJSON）から環境変数 `CF_DNS_API_TOKEN` に変更。

## 変更内容
- `compose.cloudflare.yaml`（新規）: gcloud版ベース。`secrets`ブロック削除、`environment`を`CF_DNS_API_TOKEN`のみに、`dnschallenge.provider=cloudflare`、`resolvers=1.1.1.1:53,8.8.8.8:53`追加。他サービス・ラベルは不変。
- `.env.cloudflare.example`（新規）: `CF_DNS_API_TOKEN`とトークン発行手順コメント（DNS:Edit + Zone:Read、Zone限定）。
- `README.md`: Cloudflare利用手順を追加。
- 設計ドキュメント / 実装プランを `docs/superpowers/` に追加。
- `.gitignore`: SDDスクラッチ除外。

## 検証
- `docker compose -f compose.cloudflare.yaml config` 通過（YAML妥当・環境変数補間OK）。
- gcloud版との差分がprovider関連のみであることを確認。
- 最終ブランチ全体レビュー: findings なし。

## 運用者向け残作業（このPRの範囲外）
- Cloudflare APIトークン発行 → ローカル`.env`に記入
- `*.local.challtech.dev A → 127.0.0.1`（DNS only）確認
- CAA: ZeroSSLの発行元はSectigo。張るなら `0 issue "sectigo.com"`（旧 `pki.goog` が残っていると弾かれる）
- 切替 → 安定後にCloud DNSゾーンをエクスポート・削除、MX/TXT移行確認
- 詳細は `docs/superpowers/specs/2026-07-18-traefik-cloudflare-dns-migration-design.md` の運用ランブック参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)